### PR TITLE
prevent undefined errors when there is no value or only 1 value

### DIFF
--- a/react_components/cell.js
+++ b/react_components/cell.js
@@ -37,7 +37,9 @@ var OwlCell = React.createClass({
 			var options;
 
 			if (props.column.type === 'select_multiple') {
-				split = _.compact(props.row[props.column.field].split('||'));
+				split = _.compact(
+					!props.row[props.column.field] ? props.row[props.column.field] : props.row[props.column.field].split('||')
+				);
 			}
 
 			if (split.length > 1) {


### PR DESCRIPTION
prevent undefined errors when there is no value or only 1 value for select multiples.

![split_error](https://cloud.githubusercontent.com/assets/9440455/5380816/8795bf9e-8069-11e4-9c48-eaf6fed8fd62.png)
