### PR TITLE
prevent error when sorting by a column with unset option text

### DIFF
--- a/src/service.js
+++ b/src/service.js
@@ -127,7 +127,7 @@ function owlTableService ($http, $rootScope, $filter, owlConstants, owlResource)
 			if (sortColumn.type.indexOf('select') > -1) {
 				return $filter('orderBy')(data, function (datum) {
 					var option = _.where(sortColumn.options, {'value': datum[sortColumn.field]})[0];
-					var text = $('<p>').html(option.text).text();
+					var text = (!option ? '' : $('<p>').html(option.text).text());
 					return text;
 				}, reverse);
 			}


### PR DESCRIPTION
if you try to sort by a column that has an unset option it returns an error 'cant read property text of undefined'
