### PR TITLE
prevent error when syncing data from view with child records

### DIFF
--- a/dist/owl-table.js
+++ b/dist/owl-table.js
@@ -1389,6 +1389,14 @@ angular.module('owlTable')
 
 		service.syncDataFromView = function (row, column, value) {
 			var modelRow = _(this.data).where({id: row.id}).first();
+
+			//if not found it is probably a child record, so check the children
+			if (typeof modelRow === 'undefined') {
+				var modelRow = _.find(this.data, function (data) {
+					return _(data.children).where({id: row.id}).first();
+				});
+			}
+
 			modelRow[column.field] = value;
 			$rootScope.$apply((function () {
 				this.hasChangedData = true;
@@ -1419,7 +1427,7 @@ angular.module('owlTable')
 						if (typeof column.visible === 'undefined') {
 							column.visible = true;
 						}
-						
+
 						return column.visible !== false;
 					});
 

--- a/src/services/owlTableService.js
+++ b/src/services/owlTableService.js
@@ -142,6 +142,14 @@
 
 		service.syncDataFromView = function (row, column, value) {
 			var modelRow = _(this.data).where({id: row.id}).first();
+
+			//if not found it is probably a child record, so check the children
+			if (typeof modelRow === 'undefined') {
+				var modelRow = _.find(this.data, function (data) {
+					return _(data.children).where({id: row.id}).first();
+				});
+			}
+
 			modelRow[column.field] = value;
 			$rootScope.$apply((function () {
 				this.hasChangedData = true;
@@ -172,7 +180,7 @@
 						if (typeof column.visible === 'undefined') {
 							column.visible = true;
 						}
-						
+
 						return column.visible !== false;
 					});
 


### PR DESCRIPTION
If the matching modelRow is not found, search the data.children for a match.

There doesn't seem to be a deep find in lo dash so I nested a find within a find.
